### PR TITLE
Add pace() operator: lossless throttle with optional interval curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,22 +206,29 @@ Sx.from(text_edit.text_changed).throttle(0.25).subscribe(func(): print(text_edit
 ```
 
 ### Pacing
-`pace()` is a lossless variant of `throttle()`: instead of dropping items that arrive during the interval, it queues them and emits them later, in order, spaced out. No item is ever lost.
+Sx provides a `pace()` operator, which spaces out events according to an interval.
+Unlike `throttle()`, no event is ever dropped: a burst is queued and drained in order.
 
-The interval is either a float — the first item of a burst emits instantly, the rest are spaced by the value — or a `Callable(event_n: int) -> float` consulted for every item, including the first. `event_n` counts items in the current burst and resets to 0 once `reset_after` seconds pass without a new incoming item.
+`pace()` accepts a constant interval. The first event is emitted immediately and each following one is spaced out by `interval` seconds:
 
 ```gdscript
 signal bonus_found(bonus: Bonus)
 
-# Simple version: play the sound for every bonus, at most one per 0.5s.
+# Play the sound for every bonus, at most one per 0.5s.
 # A burst of bonuses drains in order, nothing dropped.
 Sx.from(bonus_found)\
 	.pace(0.5)\
 	.subscribe(_play_sound)
+```
 
-# Function version: a pacing curve. First sound instant, the second waits 0.5s,
-# then the gap shrinks linearly down to 0.1s by the 10th, so big bursts drain faster.
-# After 2.0s without a bonus, the curve restarts at event 0.
+You can also pass a function to compute a dynamic interval. It is called with the event's index (0, 1, 2, ...) and returns the gap before that event. Return `0.0` for index 0 to emit the first one instantly.
+
+The optional `reset_after` restarts the counting after that many seconds without a new event (default: never).
+
+```gdscript
+# The first bonus is instant, the next ones are paced by 0.5s,
+# and after 10 events by 0.1s.
+# After 2.0s without a bonus, the counter restarts at 0.
 Sx.from(bonus_found)\
 	.pace(_bonus_found_pace_interval, 2.0)\
 	.subscribe(_play_sound)
@@ -229,9 +236,14 @@ Sx.from(bonus_found)\
 func _bonus_found_pace_interval(event_n: int) -> float:
 	if event_n == 0:
 		return 0.0
-	return clampf(remap(event_n, 1, 10, 0.5, 0.1), 0.1, 0.5)
+	elif event_n <= 10:
+		return 0.5
+	else:
+		return 0.1
 ```
 
+This pacing can be used to turn a burst of events into a *slot machine* style scoring system, going
+"ding....ding...ding.ding.ding.dingdingdingdingdgdgdg".
 
 ### Scan operator
 Sx allows for scanning and buffering incoming values inside a stateful operator. This operator behaves similarly to `reduce()` in functional programming.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,33 @@ Sx.from(text_edit.text_changed).debounce(0.25).subscribe(func(): print(text_edit
 Sx.from(text_edit.text_changed).throttle(0.25).subscribe(func(): print(text_edit.text)) # text will be printed every 0.25 seconds when typing continuously.
 ```
 
+### Pacing
+`pace()` is a lossless variant of `throttle()`: instead of dropping items that arrive during the interval, it queues them and emits them later, in order, spaced out. No item is ever lost.
+
+The interval is either a float — the first item of a burst emits instantly, the rest are spaced by the value — or a `Callable(event_n: int) -> float` consulted for every item, including the first. `event_n` counts items in the current burst and resets to 0 once `reset_after` seconds pass without a new incoming item.
+
+```gdscript
+signal bonus_found(bonus: Bonus)
+
+# Simple version: play the sound for every bonus, at most one per 0.5s.
+# A burst of bonuses drains in order, nothing dropped.
+Sx.from(bonus_found)\
+	.pace(0.5)\
+	.subscribe(_play_sound)
+
+# Function version: a pacing curve. First sound instant, the second waits 0.5s,
+# then the gap shrinks linearly down to 0.1s by the 10th, so big bursts drain faster.
+# After 2.0s without a bonus, the curve restarts at event 0.
+Sx.from(bonus_found)\
+	.pace(_bonus_found_pace_interval, 2.0)\
+	.subscribe(_play_sound)
+
+func _bonus_found_pace_interval(event_n: int) -> float:
+	if event_n == 0:
+		return 0.0
+	return clampf(remap(event_n, 1, 10, 0.5, 0.1), 0.1, 0.5)
+```
+
 
 ### Scan operator
 Sx allows for scanning and buffering incoming values inside a stateful operator. This operator behaves similarly to `reduce()` in functional programming.
@@ -568,6 +595,7 @@ for key in dict:
 * take
 * take_while
 * throttle
+* pace
 
 Please note that full implementation of all Rx operators is NOT a goal of this library.
 If you have a more complex problem that cannot be solved with Sx, then use GodotRx instead.

--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ for key in dict:
 * map
 * merge
 * merge_from
+* pace
 * scan
 * skip
 * skip_while
@@ -595,7 +596,6 @@ for key in dict:
 * take
 * take_while
 * throttle
-* pace
 
 Please note that full implementation of all Rx operators is NOT a goal of this library.
 If you have a more complex problem that cannot be solved with Sx, then use GodotRx instead.

--- a/addons/signal_extensions/operators/sx_pace_operator.gd
+++ b/addons/signal_extensions/operators/sx_pace_operator.gd
@@ -1,0 +1,60 @@
+extends Sx.Operator
+
+
+var _interval: Variant
+var _reset_after: float
+var _process_always: bool
+var _process_in_physics: bool
+var _ignore_timescale: bool
+
+var _event_n := 0
+var _last_arrival := -INF
+var _last_fire := -INF
+
+
+func _init(interval: Variant, reset_after: float, process_always: bool, process_in_physics: bool, ignore_timescale: bool):
+	_interval = interval
+	_reset_after = reset_after
+	_process_always = process_always
+	_process_in_physics = process_in_physics
+	_ignore_timescale = ignore_timescale
+
+
+func clone() -> Sx.Operator:
+	return Sx.PaceOperator.new(_interval, _reset_after, _process_always, _process_in_physics, _ignore_timescale)
+
+
+func evaluate(args: Array[Variant]) -> Sx.OperatorResult:
+	var now := Time.get_ticks_msec() / 1000.0
+	if now - _last_arrival > _reset_after:
+		_event_n = 0
+	_last_arrival = now
+
+	var gap := _gap_for(_event_n)
+	# The first event of a burst waits gap from its own arrival; later events space out from the
+	# previous fire. Clamp so an event never fires in the past nor before an already-scheduled
+	# emission (keeps order even when the interval curve shrinks or a reset lands mid-drain).
+	var fire_at := (now + gap) if _event_n == 0 else (_last_fire + gap)
+	fire_at = maxf(fire_at, maxf(now, _last_fire))
+	_event_n += 1
+	_last_fire = fire_at
+
+	var wait := fire_at - now
+	if wait > 0.0:
+		await Sx.get_tree().create_timer(
+			wait,
+			_process_always,
+			_process_in_physics,
+			_ignore_timescale
+		).timeout
+	return Sx.OperatorResult.new(true, args)
+
+
+func _gap_for(n: int) -> float:
+	if _interval is Callable:
+		return float(_interval.call(n))
+	if _interval is float:
+		return 0.0 if n == 0 else _interval
+
+	push_error("Invalid interval type: %s" % _interval)
+	return 0.0

--- a/addons/signal_extensions/signals/sx_signal.gd
+++ b/addons/signal_extensions/signals/sx_signal.gd
@@ -112,6 +112,16 @@ func merge_from(signals: Array[Signal]) -> SxSignal:
 	return merge(converted)
 
 
+## Paces the signal without dropping any item.
+## [b]interval[/b] can be a float or a function: func(event_n: int) -> float.
+## This method has arguments consistent with Godot's [method SceneTree.create_timer] method.
+## See that method's documentation for more information.
+func pace(interval: Variant, reset_after := INF, process_always := true, process_in_physics := false, ignore_timescale := false) -> SxSignal:
+	var cloned := clone()
+	cloned._operators.append(Sx.PaceOperator.new(interval, reset_after, process_always, process_in_physics, ignore_timescale))
+	return cloned
+
+
 ## Scans the emitted items and can reduce them to a single value over time.
 ## Reducing function: func(acc: ACC_TYPE, ...args: Array[Variant]) -> ACC_TYPE
 func scan(callable: Callable, initial_value: Variant) -> SxSignal:
@@ -169,19 +179,6 @@ func take_while(callable: Callable) -> SxSignal:
 func throttle(throttle_time: float, process_always := true, process_in_physics := false, ignore_timescale := false) -> SxSignal:
 	var cloned := clone()
 	cloned._operators.append(Sx.ThrottleOperator.new(throttle_time, process_always, process_in_physics, ignore_timescale))
-	return cloned
-
-
-## Paces emissions without dropping any (a lossless [method throttle]): each item waits so that
-## at least [b]interval[/b] separates emissions, and queued items emit in order.
-## [b]interval[/b] is a float (the first item of a burst emits instantly, the rest are spaced),
-## or a Callable(event_n: int) -> float consulted for every item including the first. event_n
-## counts items in the current burst and resets to 0 after [b]reset_after[/b] seconds without a
-## new incoming item.
-## The remaining arguments are consistent with Godot's [method SceneTree.create_timer] method.
-func pace(interval: Variant, reset_after := INF, process_always := true, process_in_physics := false, ignore_timescale := false) -> SxSignal:
-	var cloned := clone()
-	cloned._operators.append(Sx.PaceOperator.new(interval, reset_after, process_always, process_in_physics, ignore_timescale))
 	return cloned
 
 

--- a/addons/signal_extensions/signals/sx_signal.gd
+++ b/addons/signal_extensions/signals/sx_signal.gd
@@ -172,6 +172,19 @@ func throttle(throttle_time: float, process_always := true, process_in_physics :
 	return cloned
 
 
+## Paces emissions without dropping any (a lossless [method throttle]): each item waits so that
+## at least [b]interval[/b] separates emissions, and queued items emit in order.
+## [b]interval[/b] is a float (the first item of a burst emits instantly, the rest are spaced),
+## or a Callable(event_n: int) -> float consulted for every item including the first. event_n
+## counts items in the current burst and resets to 0 after [b]reset_after[/b] seconds without a
+## new incoming item.
+## The remaining arguments are consistent with Godot's [method SceneTree.create_timer] method.
+func pace(interval: Variant, reset_after := INF, process_always := true, process_in_physics := false, ignore_timescale := false) -> SxSignal:
+	var cloned := clone()
+	cloned._operators.append(Sx.PaceOperator.new(interval, reset_after, process_always, process_in_physics, ignore_timescale))
+	return cloned
+
+
 func _clone() -> SxSignal:
 	return null
 	

--- a/addons/signal_extensions/sx_autoload.gd
+++ b/addons/signal_extensions/sx_autoload.gd
@@ -11,6 +11,7 @@ const ElementAtOperator := preload("res://addons/signal_extensions/operators/sx_
 const FilterOperator := preload("res://addons/signal_extensions/operators/sx_filter_operator.gd")
 const FirstOperator := preload("res://addons/signal_extensions/operators/sx_first_operator.gd")
 const MapOperator := preload("res://addons/signal_extensions/operators/sx_map_operator.gd")
+const PaceOperator := preload("res://addons/signal_extensions/operators/sx_pace_operator.gd")
 const ScanOperator := preload("res://addons/signal_extensions/operators/sx_scan_operator.gd")
 const SkipOperator := preload("res://addons/signal_extensions/operators/sx_skip_operator.gd")
 const SkipWhileOperator := preload("res://addons/signal_extensions/operators/sx_skip_while_operator.gd")
@@ -18,7 +19,6 @@ const TakeOperator := preload("res://addons/signal_extensions/operators/sx_take_
 const TakeWhileOperator := preload("res://addons/signal_extensions/operators/sx_take_while_operator.gd")
 const DebounceOperator := preload("res://addons/signal_extensions/operators/sx_debounce_operator.gd")
 const ThrottleOperator := preload("res://addons/signal_extensions/operators/sx_throttle_operator.gd")
-const PaceOperator := preload("res://addons/signal_extensions/operators/sx_pace_operator.gd")
 
 const BasicSignal := preload("res://addons/signal_extensions/signals/sx_basic_signal.gd")
 const MergedSignal := preload("res://addons/signal_extensions/signals/sx_merged_signal.gd")

--- a/addons/signal_extensions/sx_autoload.gd
+++ b/addons/signal_extensions/sx_autoload.gd
@@ -18,6 +18,7 @@ const TakeOperator := preload("res://addons/signal_extensions/operators/sx_take_
 const TakeWhileOperator := preload("res://addons/signal_extensions/operators/sx_take_while_operator.gd")
 const DebounceOperator := preload("res://addons/signal_extensions/operators/sx_debounce_operator.gd")
 const ThrottleOperator := preload("res://addons/signal_extensions/operators/sx_throttle_operator.gd")
+const PaceOperator := preload("res://addons/signal_extensions/operators/sx_pace_operator.gd")
 
 const BasicSignal := preload("res://addons/signal_extensions/signals/sx_basic_signal.gd")
 const MergedSignal := preload("res://addons/signal_extensions/signals/sx_merged_signal.gd")

--- a/test/operators/sx_pace_operator_test.gd
+++ b/test/operators/sx_pace_operator_test.gd
@@ -1,0 +1,81 @@
+# GdUnit generated TestSuite
+class_name SxPaceOperatorTest
+extends GdUnitTestSuite
+@warning_ignore('unused_parameter')
+@warning_ignore('return_value_discarded')
+
+# TestSuite generated from
+const __source = 'res://addons/signal_extensions/operators/sx_pace_operator.gd'
+const interval := 0.1
+
+var operator: Sx.PaceOperator
+
+
+func before_test() -> void:
+	operator = Sx.PaceOperator.new(interval, INF, true, false, false)
+
+
+func test_evaluate_paces_without_dropping() -> void:
+	var start := Time.get_ticks_msec()
+	var result: Sx.OperatorResult
+
+	# The first item of a burst passes through immediately.
+	result = await operator.evaluate([1, 2])
+	assert_bool(result.ok).is_true()
+	assert_array(result.args).has_size(2).contains([1, 2])
+	assert_int(Time.get_ticks_msec() - start).is_less(50)
+
+	# Subsequent items are delayed to keep the interval, never dropped.
+	result = await operator.evaluate([3, 4])
+	assert_bool(result.ok).is_true()
+	assert_array(result.args).has_size(2).contains([3, 4])
+	assert_int(Time.get_ticks_msec() - start).is_greater_equal(80)
+
+	result = await operator.evaluate([5, 6])
+	assert_bool(result.ok).is_true()
+	assert_int(Time.get_ticks_msec() - start).is_greater_equal(180)
+
+
+func test_evaluate_with_interval_function() -> void:
+	operator = Sx.PaceOperator.new(
+		func(event_n: int) -> float: return event_n * interval,
+		INF, true, false, false
+	)
+	var start := Time.get_ticks_msec()
+
+	# f(0) = 0 -> immediate.
+	await operator.evaluate([1])
+	assert_int(Time.get_ticks_msec() - start).is_less(50)
+
+	# f(1) = 0.1 -> spaced from the previous emission.
+	await operator.evaluate([2])
+	assert_int(Time.get_ticks_msec() - start).is_greater_equal(80)
+
+	# f(2) = 0.2 -> cumulative 0.3.
+	await operator.evaluate([3])
+	assert_int(Time.get_ticks_msec() - start).is_greater_equal(260)
+
+
+func test_event_counter_resets_after_silence() -> void:
+	operator = Sx.PaceOperator.new(
+		func(event_n: int) -> float: return 0.0 if event_n == 0 else 0.5,
+		0.1, true, false, false
+	)
+
+	await operator.evaluate([1])
+
+	# Silence longer than reset_after: the next item starts a fresh burst -> instant again.
+	await await_millis(200)
+	var start := Time.get_ticks_msec()
+	await operator.evaluate([2])
+	assert_int(Time.get_ticks_msec() - start).is_less(50)
+
+
+func test_cloning() -> void:
+	var cloned := operator.clone()
+	assert_float(cloned._interval).is_equal(interval)
+	assert_float(cloned._reset_after).is_equal(INF)
+	assert_bool(cloned._process_always).is_true()
+	assert_bool(cloned._process_in_physics).is_false()
+	assert_bool(cloned._ignore_timescale).is_false()
+	assert_object(cloned).is_not_same(operator)


### PR DESCRIPTION
pace() queues items that arrive during the interval and emits them later, in order, spaced out. Nothing is ever dropped (unlike throttle()).

The interval can be a float (first item is emitted, then others are spaced) or a function `f(event_n: int) -> float` called for every items.

I used this to pace some bonus feedback. Instead of sending 20 events at the same time, you get that slot machine effect doing "ding...ding...ding..ding.ding.dingdingdingdingdingdingding".